### PR TITLE
Split out the robotstxt extraction into a separate command

### DIFF
--- a/newshomepages/extract/cli.py
+++ b/newshomepages/extract/cli.py
@@ -5,6 +5,7 @@ from .consolidate import cli as cli_consolidate
 from .hyperlinks import cli as cli_hyperlinks
 from .items import cli as cli_items
 from .lighthouse import cli as cli_lighthouse
+from .robotstxt import cli as cli_robotstxt
 from .wayback import cli as cli_wayback
 
 cli_group = click.CommandCollection(
@@ -14,6 +15,7 @@ cli_group = click.CommandCollection(
         cli_accessibility,
         cli_hyperlinks,
         cli_lighthouse,
+        cli_robotstxt,
         cli_wayback,
     ]
 )

--- a/newshomepages/site.py
+++ b/newshomepages/site.py
@@ -1,16 +1,12 @@
 import json
-import sqlite3
 import warnings
 from pathlib import Path
-from urllib.parse import urlparse
 
 import click
 import jinja2
 import numpy as np
 import pandas as pd
-import requests
 import spectra
-import sqlite_robotstxt
 from rich import print
 from rich.progress import track
 from slugify import slugify
@@ -313,69 +309,22 @@ def performance_ranking():
 def robotstxt():
     """Create the robotstxt page based on most recently scrape robots.txt files."""
     # Read in our dataset
-    robotstxt_df = utils.get_extract_df("robotstxt-files.csv")
-    robotstxt_df["mtime"] = pd.to_datetime(robotstxt_df["mtime"])
-
-    # robotstxt-file has multiple robots.txt scrapes per day - consolidate to just the most recent one
-    latest_rows_index = robotstxt_df.groupby("identifier")["mtime"].idxmax()
-    robotstxt_df = robotstxt_df.loc[latest_rows_index]
-
-    # Merge sites.csv with robotstxt_df to get site name, URL, etc.
-    site_df = utils.get_site_df()
-    site_df.handle = site_df.handle.str.lower()
-    robotstxt_df.handle = robotstxt_df.handle.str.lower()
-    robotstxt_df = site_df.merge(robotstxt_df, on="handle", how="inner")
-
-    # calculate the full URL to the site's robots.txt file
-    # url_x because that's the original site_df["url"], which was renamed in the merge
-    robotstxt_df["robotstxt_url"] = robotstxt_df["url_x"].apply(
-        lambda url: urlparse(url)._replace(path="robots.txt").geturl()
+    robotstxt_df = utils.get_extract_df(
+        "robotstxt-sample.csv",
+        usecols=[
+            "handle",
+            "user_agent",
+            "rules",
+        ],
+        dtype={
+            "handle": str,
+            "user_agent": str,
+            "rules": str,
+        },
     )
-
-    # fetch the cached robots.txt file for the site
-    # url_y because that's the robotstxt_df["url"], which was renamed in the merge
-    robotstxt_df["robotstxt"] = robotstxt_df["url_y"].apply(
-        lambda url: requests.get(url).text
-    )
-
-    # Using the sqlite-robotsxt SQLite extension for parsing the robots.txt file
-    db = sqlite3.connect(":memory:")
-    db.enable_load_extension(True)
-    sqlite_robotstxt.load(db)
-    db.enable_load_extension(False)
-
-    # Only export a few columns to the SQLite database for simplicity
-    robotstxt_df[["handle", "name", "robotstxt_url", "robotstxt"]].to_sql(
-        "sites", con=db
-    )
-    #
-    db.execute(
-        """
-      CREATE TABLE rules AS
-      WITH rules AS (
-        SELECT
-          handle,
-          robotstxt_rules.user_agent,
-          group_concat(printf('%s: %s', rule_type, path),  char(10)) as rules
-        FROM sites
-        JOIN robotstxt_rules(sites.robotstxt)
-        GROUP BY 1, 2
-      )
-      SELECT
-        sites.handle,
-        name,
-        robotstxt_url,
-        rules.*
-      FROM sites
-      LEFT JOIN rules ON rules.handle = sites.handle
-    """
-    )
-
-    # export that rules SQLite table back to a dataframe
-    rules_df = pd.read_sql("select * from rules", con=db)
 
     # Get only the rules that pertain to GPTBot
-    gptbot_rules_list = rules_df[rules_df["user_agent"] == "GPTBot"].to_dict(
+    gptbot_rules_list = robotstxt_df[robotstxt_df["user_agent"] == "GPTBot"].to_dict(
         orient="records"
     )
 

--- a/newshomepages/utils.py
+++ b/newshomepages/utils.py
@@ -115,13 +115,35 @@ def write_json(
 
 
 @retry(tries=3, delay=15, backoff=2)
-def get_url(url: str, timeout: int = 30, user_agent: str | None = None):
-    """Get the provided URL."""
+def get_url(
+    url: str, timeout: int = 30, user_agent: str | None = None, verbose: bool = False
+):
+    """Get the provided URL.
+
+    Args:
+        url (str): The URL to fetch.
+        timeout (int): The number of seconds to wait before timing out. (Default: 30)
+        user_agent (str): The user agent to use in the request. (Default: None)
+        verbose (bool): Whether or not to log the action prior to execution. (Default: False)
+
+    Returns a requests.Response object.
+    """
+    # Set up headers
     headers = {}
     if user_agent:
         headers["User-Agent"] = user_agent
+
+    # Log
+    if verbose:
+        print(f"📡 Fetching {url}")
+
+    # Get the URL
     r = requests.get(url, timeout=timeout, headers=headers)
+
+    # Raise an error if the request failed
     assert r.ok
+
+    # Return the response
     return r
 
 
@@ -479,6 +501,14 @@ def get_lighthouse_df() -> pd.DataFrame:
     Returns a DataFrame.
     """
     return _get_extract_files_df("lighthouse-files.csv")
+
+
+def get_robotstxt_df() -> pd.DataFrame:
+    """Get the full list of robots.txt files from our extracts.
+
+    Returns a DataFrame.
+    """
+    return _get_extract_files_df("robotstxt-files.csv")
 
 
 def get_wayback_df() -> pd.DataFrame:

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(
         "spacy",
         "spectra",
         "Mastodon.py",
+        "sqlite-robotstxt",
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR to your PR would split out the collection of the robotstxt sample extraction. It would also take advantage of the caching routines our drudge and lighthouse pages use, in partnership with GitHub Actions caching, to reduce the number of web requests required to assemble a new sample.

(Annoyingly, it also catches you up with the main branch. So there's a bunch of other small stuff. If you were to merge main on your end that could remove those bits from this PR.)

Take a look at the broad strokes and see what you think. I expect there will be a little more clean up required before we can get this merged into the production branch. I mainly wanted to raise this one key issue with you and get some feedback.